### PR TITLE
feat: refine about, contact, home copy and experience labels

### DIFF
--- a/src/constants/about.ts
+++ b/src/constants/about.ts
@@ -4,14 +4,14 @@ export const ABOUT_DATA: AboutData = {
   title: 'About Me',
   description: [
     {
-      ko: '정적인 데이터 검수에서 나아가 사용자 상호작용을 직접 설계하고자 개발자로 전향하였습니다.\n 게임 로컬라이징 경험을 통해 텍스트, 그래픽, 상호작용이 결합하여\n완성된 UX를 만드는 과정을 체득했습니다.',
-      en: 'Pivoted to development to personally design user interactions beyond static data validation. My experience in game localization gave me a deep understanding of how text, graphics, and interaction converge to create a complete UX.',
-      ja: '静的データの検収にとどまらず、ユーザーインタラクションを自ら設計するためにエンジニアへ転向しました。ゲームローカライズの経験を通じ、テキスト、グラフィック、相互作用が融合して一つの完成されたUXを生み出すプロセスを体得しました。',
+      en: 'Transitioned from game localization—where precision in text and interaction is paramount—to frontend development to personally engineer seamless user experiences. I focus on solving technical challenges like interval drift to ensure data integrity in any environment.',
+      ko: '텍스트와 상호작용의 정밀함이 생명인 게임 로컬라이징 경험을 바탕으로, 완벽한 UX를\n 직접 엔지니어링하고자 개발자로 전향했습니다. 런타임 환경의 인터벌 오차를 보정하는 등 어떤 조건에서도 데이터 무결성을 보장하는 해결책을 찾는 데 집중합니다.',
+      ja: 'テキストと相互作用の精密さが不可欠なゲームローカライズの経験を活かし、完璧なUXを自らエンジニアリングするために開発者へと転向しました。ランタイム環境のインターバル誤差を補正するなど、あらゆる条件下でデータの整合性を保証する解決策を見出すことに注力しています。',
     },
     {
-      ko: '복잡한 비즈니스 로직을 상태 모델 관점에서 구조화하는 데 강점이 있으며,\n Zustand와 TanStack Query를 활용해 서버와 UI 상태를 명확히 분리하여 확장성 있는\n아키텍처를 설계하는 것을 지향합니다.',
-      en: 'I specialize in structuring complex business logic through state modeling, focusing on designing scalable architectures by decoupling server and UI states using Zustand and TanStack Query.',
-      ja: '複雑なビジネスロジックを状態モデルの観点から構造化することに強みがあり、ZustandやTanStack Queryを活用してサーバーとUIの状態を明確に分離し、拡張性のあるアーキテクチャを設計することを追求しています。',
+      en: 'I excel at structuring complex logic through state modeling, leveraging TanStack Query for optimistic updates and Zustand for clean UI state management to build highly responsive, scalable systems.',
+      ko: '복잡한 로직을 상태 모델 관점에서 구조화하는 데 강점이 있습니다. TanStack Query의 낙관적 업데이트와 Zustand를 활용해 서버와 UI 상태를 명확히 분리하며, 사용자에게 즉각적인 피드백을 주는 고성능 시스템을 지향합니다.',
+      ja: '複雑なロジックを状態モデルの観点から構造化することに強みがあります。TanStack Queryの楽観的アップデートとZustandを活用してサーバーとUIの状態を明確に分離し、ユーザーに即時フィードバックを提供する高性能なシステムを追求しています。',
     },
   ],
   quickFacts: [

--- a/src/constants/contactContent.ts
+++ b/src/constants/contactContent.ts
@@ -3,23 +3,23 @@ import type { ContactContent } from '@/types/portfolio';
 export const CONTACT_CONTENT: ContactContent = {
   description: [
     {
-      en: 'I am a frontend developer focused on building clean, maintainable, and user-centric interfaces.',
-      ko: '유지보수가 용이하고 사용자 중심 인터페이스를 구축하는 데 집중하는 프론트엔드 개발자입니다.',
-      ja: '保守性の高いユーザ構築に注力するフロントエンド開発者です。',
+      en: 'I am a frontend developer who balances technical rigor with a user-centric perspective to build reliable, high-performance interfaces.',
+      ko: '기술적 엄밀함과 사용자 중심의 관점을 조화시켜, 신뢰할 수 있는 고성능 인터페이스를 구축하는 프론트엔드 개발자입니다.',
+      ja: '技術的な厳密さとユーザー中心の視点を調和させ、信頼性の高い高性能なインターフェースを構築するフロントエンド開発者です。',
     },
     {
-      en: 'Leveraging my professional background, I prioritize clear communication and proactive collaboration.',
-      ko: '이전의 실무 경험을 바탕으로 명확한 커뮤니케이션과 주도적인 협업을 최우선으로 생각합니다.',
-      ja: 'これまでの実務経験を活かし、円滑なコミュニケーションと主体的な協業を大切にしています。',
+      en: 'Drawing on my professional experience in localization, I prioritize clear communication and proactive problem-solving within a team.',
+      ko: '로컬라이징 실무 경험을 바탕으로, 팀 내에서 명확한 커뮤니케이션과 주도적인 문제 해결을 최우선으로 생각합니다.',
+      ja: 'ローカライズ実務経験を活かし、チーム内での明確なコミュニケーションと主体的な問題解決を大切にしています。',
     },
     {
-      en: 'I am currently seeking new frontend opportunities and would be glad to connect.',
-      ko: '현재 새로운 프론트엔드 직무 기회를 찾고 있으며, 좋은 인연이 닿기를 기대합니다.',
-      ja: '現在フロントエンドエンジニアとしての新たな機会を探しており、ぜひご縁があれば幸いです。',
+      en: 'I am currently seeking new frontend opportunities and would be glad to discuss how I can contribute to your team.',
+      ko: '현재 새로운 프론트엔드 직무 기회를 찾고 있으며, 제가 팀에 어떻게 기여할 수 있을지 함께 논의하고 싶습니다.',
+      ja: '現在、フロントエンドエンジニアとしての新たな機会を探しており、チームにどのように貢献できるかぜひお話しできれば幸いです。',
     },
     {
       en: 'I typically respond within 24 hours.',
-      ko: '24시간 안에 연락드리겠습니다.',
+      ko: '24시간 이내에 답변드리겠습니다.',
       ja: '通常24時間以内に返信いたします。',
     },
   ],
@@ -36,9 +36,9 @@ export const CONTACT_CONTENT: ContactContent = {
     },
     description: [
       {
-        en: 'I am looking for full-time roles where I can contribute to high-impact products and grow alongside a collaborative team.',
-        ko: '임팩트 있는 제품 개발에 기여하며 팀과 함께 성장할 수 있는 정규직 포지션을 희망합니다.',
-        ja: '価値あるプロダクト開発に貢献し、チームと共に成長できるフルタイムのポジションを希望しています。',
+        en: 'I am looking for roles where I can leverage my expertise in state management and performance optimization to build high-impact products.',
+        ko: '상태 관리와 성능 최적화 역량을 발휘하여 임팩트 있는 제품 개발에 기여하고, 함께 성장할 수 있는 포지션을 희망합니다.',
+        ja: '状態管理とパフォーマンス最適化のスキルを活かし、価値あるプロダクト開発に貢献しながら共に成長できるポジションを希望しています。',
       },
     ],
     availability: 'Available for hire',

--- a/src/constants/experience.ts
+++ b/src/constants/experience.ts
@@ -51,7 +51,7 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     id: 2,
     period: '2019.04 - 2023.09',
     role: {
-      ko: '로컬라이징 QA 및 프로젝트 담당 (파견사원)',
+      ko: '로컬라이징 QA 및 프로젝트 담당 (파견)',
       en: 'Localization QA & Project Specialist (Contractor)',
       ja: 'ローカライズQAおよびプロジェクト担当 (派遣)',
     },
@@ -92,7 +92,7 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     id: 3,
     period: '2018.07 - 2019.04',
     role: {
-      ko: '행정 지원 (파견사원)',
+      ko: '행정 지원 (파견)',
       en: 'Administrative Coordinator (Contractor)',
       ja: '行政サポート (派遣)',
     },
@@ -124,9 +124,9 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     id: 4,
     period: '2016.09 - 2018.02',
     role: {
-      ko: '플랫폼 운영 서포트 (파견사원)',
+      ko: '플랫폼 운영 서포트 (계약사원)',
       en: 'Platform Operations Assistant (Contractor)',
-      ja: 'プラットフォーム運営サポート (派遣)',
+      ja: 'プラットフォーム運営サポート (契約)',
     },
     company: {
       ko: '이러닝 플랫폼 사업부',

--- a/src/constants/home.ts
+++ b/src/constants/home.ts
@@ -3,14 +3,14 @@ import type { HomeData } from '@/types/portfolio';
 export const HOME_DATA: HomeData = {
   title: 'Frontend Developer',
   subtitle: {
-    ko: '예측 가능한 상태와 확장 가능한\nUI 시스템을 설계합니다.',
-    en: 'Designing Predictable State and Scalable UI Systems',
-    ja: '予測可能な状態と拡張可能な\nUIシステムを設計します。',
+    en: 'Building Reliable Systems by Solving Runtime Errors and State Sync Challenges',
+    ko: '런타임 오차 보정과 서버 상태\n 동기화를 통해 신뢰할 수 있는\n 사용자 경험을 설계합니다.',
+    ja: 'ランタイムエラーの補正とサーバー状態の同期を通じて、\n信頼性の高いユーザーエクスペリエンスを設計します。',
   },
   description: {
-    ko: '복잡한 요구사항을 명확한 데이터 흐름으로 전환하여,\n지속 가능한 프론트엔드 아키텍처를 구축합니다.',
-    en: 'Transforming complex requirements into clear data flows\n to build sustainable frontend architectures.',
-    ja: '複雑な要求事項を明確なデータフローへと変換し、\n持続可能なフロントエンドアーキテクチャを構築します。',
+    en: 'I specialize in transforming complex business logic into high-precision, scalable frontend architectures.',
+    ko: '복잡한 비즈니스 요구사항을 정밀한 데이터 흐름으로 전환하여,\n지속 가능한 프론트엔드 아키텍처를 구축합니다.',
+    ja: '複雑なビジネス要件を精密なデータフローへと変換し、\n持속的なフロントエンドアーキテクチャを構築します。',
   },
   keywords: [
     'React',


### PR DESCRIPTION
## 📌 Description

Updated the portfolio's "About" and "Contact" sections to better reflect technical rigor and engineering-focused identity. 

## 🛠️ Key Changes

* **Identity Refinement**: Integrated keywords such as "technical rigor" and "user-centric perspective" to define a professional engineering persona.

* **Global Support**: Synchronized the tone and terminology across English, Korean, and Japanese for consistent global branding.

* **Career Alignment**: Bridged the gap between prior experience in localization and current frontend expertise by highlighting "attention to detail" and "problem-solving."

## 🧠 Design Notes

* **Action-Oriented Language**: Replaced passive greetings with proactive terms like "contribute" and "problem-solving" to appeal to hiring managers.


## ✅ Checklist

- [x] Tested the responsiveness of the updated text layouts.

