### PR TITLE
feat: set Architecture & Performance accordion to expanded by default

### DIFF
--- a/src/components/project/ProjectAccordion.tsx
+++ b/src/components/project/ProjectAccordion.tsx
@@ -18,7 +18,7 @@ interface ProjectAccordionProps {
 
 export function ProjectAccordion({ project, language }: ProjectAccordionProps) {
   return (
-    <Accordion type='single' collapsible className='w-full select-none'>
+    <Accordion type='single' collapsible defaultValue='architecture' className='w-full select-none'>
       <AccordionItem value='architecture' className='border-cyan-500/20'>
         <AccordionTrigger className='font-mono text-xs uppercase tracking-[0.2em] text-cyan-400/80 [&>svg]:text-cyan-400/80 hover:no-underline hover:text-cyan-400 hover:[&_svg]:text-cyan-400'>
           Architecture & Performance


### PR DESCRIPTION
## 📌 Description

* **Summary**: Updated the `Architecture & Performance` accordion to be expanded by default on page load.
* **Background**: Strategically optimized the initial view to showcase core architectural decisions and performance optimizations to recruiters without requiring manual interaction.

## 🛠️ Key Changes

* **UX Optimization**: Reduced cognitive load for visitors by prioritizing the most impactful technical content, ensuring a strong first impression of engineering depth.

## 🧠 Design Notes

* **Strategic Exposure**: Prioritizes 'Design Logic' over simple feature listing, forcing the highlight of system-level thinking as the primary entry point.
* **Deterministic UI**: Ensures a consistent and predictable initial UI state, aligning with the project's principle of deterministic data flow.

## 📸 ScreenShots

`before`
<img width="1267" height="780" alt="before" src="https://github.com/user-attachments/assets/e88072fe-7521-4cef-9fdf-45ec18307406" />

`after`
<img width="1257" height="828" alt="after" src="https://github.com/user-attachments/assets/1f099c8d-c8c6-49a8-9b77-0a60bd96d781" />

## ✅ Checklist

* [x] The `Architecture & Performance` accordion is expanded by default on page load.
* [x] Other sections (Challenges, Learned, etc.) remain collapsed as intended.



