### PR TITLE
Feat:Add project and contact links

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -10,7 +10,9 @@ import { useLanguage } from '@/context/LanguageProvider';
 export function ContactSection() {
   const { language } = useLanguage();
   const content = CONTACT_CONTENT;
-  const links = CONTACT_LINKS;
+  const filteredLinks = CONTACT_LINKS.filter(
+    (link) => link.label === 'Email' || link.label === 'GitHub',
+  );
 
   return (
     <section id='contact' className='relative px-6 py-24 md:py-32'>
@@ -33,8 +35,8 @@ export function ContactSection() {
           className='flex flex-col items-center text-center'
         >
           <div className='grid gap-8 md:grid-cols-2'>
-            <div className='flex flex-col gap-3'>
-              {links.map((item) => {
+            <div className='flex flex-col gap-4'>
+              {filteredLinks.map((item) => {
                 const Icon = item.icon;
                 return (
                   <Card
@@ -82,17 +84,17 @@ export function ContactSection() {
             <motion.div
               {...fadeInUp}
               transition={{ duration: 0.5, delay: 0.2 }}
-              className='flex flex-col items-baseline rounded-lg border border-[#ffffff10] bg-[#0f1115] p-8 shadow-lg shadow-cyan-500/20 '
+              className='flex flex-col items-baseline rounded-lg border border-[#ffffff10] bg-[#0f1115] p-5 shadow-lg shadow-cyan-500/20 '
             >
               <h3 className='font-mono text-sm font-medium text-cyan-400'>
                 {content.openToWork.badge[language]}
               </h3>
 
-              <p className='mt-4 text-lg font-semibold text-foreground'>
+              <p className='mt-3 text-lg font-semibold text-foreground'>
                 {content.openToWork.headline[language]}
               </p>
 
-              <p className='mt-4 leading-relaxed text-left text-muted-foreground'>
+              <p className='mt-3 leading-relaxed text-left text-muted-foreground'>
                 {content.openToWork.description.map((line, idx) => (
                   <p key={idx}>{line[language]}</p>
                 ))}

--- a/src/components/project/ProjectHero.tsx
+++ b/src/components/project/ProjectHero.tsx
@@ -4,6 +4,7 @@ import type { ProjectsData } from '@/types/portfolio';
 import type { Language } from '@/context/LanguageProvider';
 import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
+import { CONTACT_LINKS } from '@/constants/contactLink';
 
 interface ProjectHeroProps {
   project: ProjectsData;
@@ -13,6 +14,8 @@ interface ProjectHeroProps {
 export function ProjectHero({ project, language }: ProjectHeroProps) {
   const [index, setIndex] = useState(0);
   const IMAGES = ['/images/todo.png', '/images/timer.png', '/images/chart.png'];
+  const githubLink = CONTACT_LINKS.find((link) => link.label === 'GitHub');
+  const projectLink = CONTACT_LINKS.find((link) => link.label === 'DeployUrl');
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -33,6 +36,32 @@ export function ProjectHero({ project, language }: ProjectHeroProps) {
               <Badge className='w-fit rounded-full bg-white/5 px-3 py-1 font-mono text-xs text-muted-foreground border border-white/5'>
                 {project.period}
               </Badge>
+
+              {githubLink && (
+                <a
+                  className='flex h-5 w-5 items-center justify-center rounded-md'
+                  href={githubLink.href}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {githubLink.icon && (
+                    <githubLink.icon className='h-5 w-5 text-muted-foreground transition-all duration-200 ease-in hover:scale-125 hover:text-cyan-500' />
+                  )}
+                </a>
+              )}
+
+              {projectLink && (
+                <a
+                  className='flex h-5 w-5 items-center justify-center rounded-md '
+                  href={projectLink.href}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  {projectLink.icon && (
+                    <projectLink.icon className='h-5 w-5 text-muted-foreground transition-all duration-200 ease-in hover:scale-125 hover:text-cyan-500' />
+                  )}
+                </a>
+              )}
             </div>
 
             <p className='font-mono text-cyan-400/80 text-xs md:text-sm uppercase'>

--- a/src/constants/contactLink.ts
+++ b/src/constants/contactLink.ts
@@ -1,6 +1,6 @@
 import type { ContactLink } from '@/types/portfolio';
 import { Mail } from 'lucide-react';
-import { FaGithub, FaLinkedin } from 'react-icons/fa';
+import { FaGithub, FaLinkedin, FaExternalLinkAlt } from 'react-icons/fa';
 
 export const CONTACT_LINKS: ContactLink[] = [
   {
@@ -20,5 +20,11 @@ export const CONTACT_LINKS: ContactLink[] = [
     value: 'linkedin.com/in/your-id',
     href: 'https://linkedin.com/in/your-id',
     icon: FaLinkedin,
+  },
+  {
+    label: 'DeployUrl',
+    value: 'DeployUrl',
+    href: 'https://',
+    icon: FaExternalLinkAlt,
   },
 ];

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -2,7 +2,7 @@ import type { ProjectsData } from '@/types/portfolio';
 
 export const PROJECTS_DATA: ProjectsData = {
   id: 'focusdo',
-  title: 'Focusdo',
+  title: 'FocusDo',
   period: '2026.01 ~ Present',
   role: 'Planning · Design · Frontend Development',
   techStack: [


### PR DESCRIPTION
## 📌 Description

Add reusable deploy link metadata and surface GitHub/live links for the portfolio project, while tightening what is shown in the contact section.

---
## 🛠️ Key Changes
* **Contact link constants**: Add a `DeployUrl` entry with an external-link icon to `CONTACT_LINKS` so sections can reuse the live URL metadata.
* **Project hero links**: Show GitHub and DeployUrl icon buttons in `ProjectHero` next to the project period, opening in a new tab.
* **Contact section filtering**: Render only Email and GitHub contact cards and slightly adjust spacing in the open-to-work panel.
* **Project title casing**: Normalize the FocusDo project title casing in the projects constants.
---
## 🧠 Design Notes
* **Reusability**: Centralize deploy URL and icon in `CONTACT_LINKS` so future sections stay in sync with a single source of truth.
* **Signal-focused contact UI**: Limit visible contact methods in the hero contact section to the two highest-signal channels (email, GitHub).

---

## 📸 ScreenShots
`before`
<img width="1254" height="464" alt="before" src="https://github.com/user-attachments/assets/c6e7607d-5532-4d42-af4c-568275db8385" />
<img width="1262" height="638" alt="before1" src="https://github.com/user-attachments/assets/5454c27d-add0-4ade-ab7e-83821e0b2c36" />

`after`
<img width="1259" height="467" alt="after1" src="https://github.com/user-attachments/assets/596f7dcc-58d5-4063-9a8e-a6723ef67946" />
<img width="1260" height="523" alt="after2" src="https://github.com/user-attachments/assets/c5488640-d59c-4332-8299-f5048945b346" />

---

## ✅ Checklist

* [x] Manually verified contact links and project hero icons in local development