### PR TITLE
Refactor: Refine portfolio copy and improve hero, project, and skills UX

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -98,14 +98,14 @@ export function HeroSection() {
           transition={{ duration: 0.7, delay: 0.5 }}
           className='relative hidden items-center justify-center lg:flex'
         >
-          <div className='relative grid grid-cols-4 gap-5'>
+          <div className='relative grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-3'>
             {techIcons.map((tech, i) => (
               <motion.div
                 key={tech.label}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.4, delay: 0.6 + i * 0.08 }}
-                className='group relative z-10 flex h-24 w-24 flex-col items-center justify-center gap-2 rounded-xl border border-cyan-400/50 bg-cyan-500/5 backdrop-blur-sm'
+                className='group relative z-10 flex aspect-square w-20 sm:w-24 flex-col items-center justify-center gap-2 rounded-xl border border-cyan-400/50 bg-cyan-500/5 backdrop-blur-sm'
               >
                 <motion.span
                   className='absolute -inset-3 -z-10 rounded-xl bg-cyan-400/60 blur-2xl'

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -49,7 +49,7 @@ export function SkillsSection() {
                             {skill.details.map((detail, idx) => (
                               <li
                                 key={idx}
-                                className='flex items-center gap-3 text-sm text-muted-foreground'
+                                className='flex items-center gap-3 text-sm text-muted-foreground whitespace-pre-line'
                               >
                                 <span className='h-1 w-1 shrink-0 rounded-full bg-cyan-500/40' />
                                 {detail[language]}

--- a/src/components/project/Architecture.tsx
+++ b/src/components/project/Architecture.tsx
@@ -1,7 +1,7 @@
 import type { ArchitectureData } from '@/types/portfolio';
 import type { Language } from '@/context/LanguageProvider';
 import { Card, CardContent } from '../ui/card';
-import diagram from '../../../public/images/architecture-diagram.png';
+import diagram from '/images/architecture-diagram.png';
 
 interface ArchitectureProps {
   architecture: ArchitectureData;

--- a/src/components/project/ProjectHero.tsx
+++ b/src/components/project/ProjectHero.tsx
@@ -64,10 +64,10 @@ export function ProjectHero({ project, language }: ProjectHeroProps) {
             </p>
 
             <div>
-              <p className='text-sm md:text-lg whitespace-pre-line '>
+              <p className='text-sm md:text-lg whitespace-pre-line'>
                 {project.introduction[language]}
               </p>
-              <p className='text-xs md:text-sm text-muted-foreground pt-2 whitespace-pre-line '>
+              <p className='text-xs md:text-sm text-muted-foreground pt-5 whitespace-pre-line'>
                 {project.overview[language]}
               </p>
             </div>

--- a/src/constants/experience.ts
+++ b/src/constants/experience.ts
@@ -12,7 +12,7 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     company: {
       ko: '컴퓨터과학과 학사 편입',
       en: 'Bachelor’s Program (Transfer) - Computer Science',
-      ja: 'コンピュータ科学部 学士編入',
+      ja: 'コンピュータ科学科 学士編入',
     },
     isPrimary: true,
     description: {
@@ -51,9 +51,9 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     id: 2,
     period: '2019.04 - 2023.09',
     role: {
-      ko: '로컬라이징 QA 및 프로젝트 담당 (파견)',
-      en: 'Localization QA & Project Specialist (Contractor)',
-      ja: 'ローカライズQAおよびプロジェクト担当 (派遣)',
+      ko: '로컬라이징 및 프로젝트 담당 (파견)',
+      en: 'Localization & Project Specialist (Contractor)',
+      ja: 'ローカライズおよびプロジェクト担当 (派遣)',
     },
     company: {
       ko: '게임 개발 / 로컬라이징 프로젝트',
@@ -92,9 +92,9 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     id: 3,
     period: '2018.07 - 2019.04',
     role: {
-      ko: '행정 지원 (파견)',
-      en: 'Administrative Coordinator (Contractor)',
-      ja: '行政サポート (派遣)',
+      ko: '일반 사무 (파견)',
+      en: 'Office work (Contractor)',
+      ja: '一般事務 (派遣)',
     },
     company: {
       ko: '식품 제조 기업',
@@ -129,15 +129,15 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
       ja: 'プラットフォーム運営サポート (契約)',
     },
     company: {
-      ko: '이러닝 플랫폼 사업부',
-      en: 'E-Learning Platform Division',
-      ja: 'Eラーニングプラットフォーム事業部',
+      ko: '플랫폼 사업부',
+      en: 'Platform Division',
+      ja: 'グプラットフォーム事業部',
     },
     isCondensed: true,
     description: {
       ko: '이러닝 서비스 어카운트 관리 및 시스템 운영 보조 업무를 수행했습니다.',
       en: 'Supported e-learning platform operations by managing user accounts and performing routine system checks.',
-      ja: 'eラーニングサービスのアカウント管理およびシステム運営補助業務を担当しました。',
+      ja: 'e-ラーニングサービスのアカウント管理およびシステム運営補助業務を担当しました。',
     },
     achievements: [
       {

--- a/src/constants/home.ts
+++ b/src/constants/home.ts
@@ -4,16 +4,20 @@ export const HOME_DATA: HomeData = {
   title: 'Frontend Developer',
   subtitle: {
     en: `Building reliable frontend systems through clear state management and consistent data flow.`,
-    ko: `명확한 상태 관리와 일관된 데이터 흐름을 기반으로
+    ko: `명확한 상태 관리와 일관된 
+        데이터 흐름을 기반으로
         신뢰할 수 있는 프론트엔드 시스템을 설계합니다.`,
-    ja: `明確な状態管理と一貫したデータフローを基盤に、
-        信頼できるフロントエンドシステムを設計します。`,
+    ja: `明確な状態管理と一貫した
+          データフローを基盤に、信頼できる
+          フロントエンドシステムを
+          設計します。`,
   },
   description: {
     en: `I focus on designing frontend systems where data flow and state ownership are clearly defined,
         so that UI behavior remains predictable and maintainable as the application grows.`,
     ko: `데이터 흐름과 상태 소유권이 명확하게 정의된 프론트엔드 시스템을 설계하여
-          애플리케이션이 확장되더라도 UI 동작이 예측 가능하고 유지보수 가능하도록 만드는 데 집중합니다.`,
+          애플리케이션이 확장되더라도 UI 동작이 예측 가능하고 유지보수 가능하도록 만드는 데 
+          집중합니다.`,
     ja: `データフローと状態の所有関係を明確に定義したフロントエンドシステムを設計し、
           アプリケーションが拡張してもUIの挙動が予測可能で保守しやすい構造を目指しています。`,
   },

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -14,33 +14,23 @@ export const PROJECTS_DATA: ProjectsData = {
     'D3.js',
   ],
   introduction: {
-    ko: `할 일 관리와 집중 세션 기록을 결합한
-        생산성 웹 애플리케이션입니다.
-        데이터 흐름을 명확하게 유지하고
-        상태 관리가 예측 가능하도록 구조를 설계했습니다.`,
+    ko: `할 일 관리와 집중 세션 기록을 결합한 생산성 웹 애플리케이션입니다.
+        데이터 흐름을 명확하게 유지하고 상태 관리가 예측 가능하도록 구조를 설계했습니다.`,
     en: `A productivity web application that combines task management
         with focus session tracking.
         The system is structured to keep data flow predictable
         and state management explicit.`,
-    ja: `タスク管理と集中セッション記録を組み合わせた
-        生産性Webアプリケーションです。
-        データフローを明確に保ち、
-        状態管理が予測可能になるよう構造を設計しました。`,
+    ja: `タスク管理と集中セッション記録を組み合わせた生産性Webアプリケーションです。
+        データフローを明確に保ち、状態管理が予測可能になるよう構造を設計しました。`,
   },
 
   overview: {
-    ko: `애플리케이션은 명확한 상태 소유권과
-          예측 가능한 데이터 흐름을 중심으로 설계되었습니다.
-          이를 통해 UI 일관성을 높이고
-          프로젝트가 확장되더라도 유지보수가 쉬운 구조를 만들었습니다.`,
-    en: `The application focuses on clear state ownership
-          and a predictable data flow.
-          This approach improves UI consistency
-          and makes the system easier to maintain as it grows.`,
-    ja: `アプリケーションは明確な状態所有権と
-          予測可能なデータフローを中心に設計されています。
-          これによりUIの一貫性を高め、
-          システムが拡張しても保守しやすい構造を実現しました。`,
+    ko: `애플리케이션은 명확한 상태 소유권과 예측 가능한 데이터 흐름을 중심으로 설계되었습니다.
+          이를 통해 UI 일관성을 높이고 프로젝트가 확장되더라도 유지보수가 쉬운 구조를 만들었습니다.`,
+    en: `The application focuses on clear state ownership and a predictable data flow.
+          This approach improves UI consistency and makes the system easier to maintain as it grows.`,
+    ja: `アプリケーションは明確な状態所有権と予測可能なデータフローを中心に設計されています。
+          これによりUIの一貫性を高め、システムが拡張しても保守しやすい構造を実現しました。`,
   },
 
   keyFeatures: [
@@ -66,8 +56,8 @@ export const PROJECTS_DATA: ProjectsData = {
         ja: 'タスク統合型集中タイマー',
       },
       description: {
-        ko: `태스크와 집중 세션을 결합하여 각 항목별 누적 집중 시간을 
-        정확히 추적하고 관리할 수 있도록 설계했습니다.`,
+        ko: `태스크와 집중 세션을 결합하여 각 항목별 누적 집중 시간을 정확히 추적하고 
+            관리할 수 있도록 설계했습니다.`,
         en: `Integrated tasks with focus sessions to accurately track and accumulate focus time per task.`,
         ja: `タスクと集中セッションを統合し、 項目ごとの累積集中時間を正確に追跡・管理できるよう設計しました。`,
       },
@@ -79,10 +69,11 @@ export const PROJECTS_DATA: ProjectsData = {
         ja: '派生データ基盤ダッシュボード',
       },
       description: {
-        ko: `중복 상태를 추가하지 않고 기존 데이터로부터 성취 지표를 계산하여 
-              데이터 정합성과 일관성을 유지했습니다.`,
+        ko: `중복 상태를 추가하지 않고 기존 데이터로부터 성취 지표를 계산하여 데이터 정합성과 
+              일관성을 유지했습니다.`,
         en: `Computed achievement metrics from existing data without introducing redundant state, preserving data integrity and consistency.`,
-        ja: `冗長な状態を追加せず既存データから達成指標を算出することで、 データ整合性と一貫性を維持しました。`,
+        ja: `冗長な状態を追加せず既存データから達成指標を算出することで、データ整合性と
+            一貫性を維持しました。`,
       },
     },
     {
@@ -92,8 +83,8 @@ export const PROJECTS_DATA: ProjectsData = {
         ja: '週間履歴の可視化',
       },
       description: {
-        ko: `구조화된 데이터 모델을 기반으로 D3.js를 활용해 
-        주간 집중 패턴을 시각적으로 분석 가능하도록 구현했습니다.`,
+        ko: `구조화된 데이터 모델을 기반으로 D3.js를 활용해 주간 집중 패턴을 시각적으로 
+            분석 가능하도록 구현했습니다.`,
         en: `Leveraged structured data modeling with D3.js to visualize and analyze weekly focus patterns.`,
         ja: `構造化されたデータモデルを基にD3.jsを活用し、 週間の集中パターンを可視化・分析可能にしました。`,
       },
@@ -107,9 +98,8 @@ export const PROJECTS_DATA: ProjectsData = {
              데이터가 분산되며 UI 불일치 문제가 발생했습니다.`,
         en: `Managing state separately with useReducer caused data fragmentation
              between the Todo and Focus pages, which led to UI inconsistencies.`,
-        ja: `useReducerベースで状態を個別管理していたため、
-             TodoページとFocusページの間でデータが分散し、
-             UIの不整合が発生しました。`,
+        ja: `useReducerベースで状態を個別管理していたため、TodoページとFocusページの間で
+            データが分散し、UIの不整合が発生しました。`,
       },
       solution: {
         ko: `중앙 집중형 상태 관리 도구인 Zustand를 도입하여 상태 저장소를 통합하고, 
@@ -208,25 +198,23 @@ export const PROJECTS_DATA: ProjectsData = {
           ja: 'データ整合性および集約戦略',
         },
         description: {
-          ko: `데이터 무결성을 유지하기 위해 focus_sessions 테이블을 단일 진실 공급원(SSOT)으로 정의했습니다.
-        가공된 통계 데이터를 데이터베이스에 저장하지 않고, 원천 세션 데이터를 기반으로 
-        클라이언트에서 집계를 수행해 생산성 지표를 계산하도록 설계했습니다.
-        이 구조는 Dual-write로 인한 데이터 불일치 위험을 제거합니다.`,
+          ko: `데이터 무결성을 유지하기 위해 focus_sessions 테이블을 단일 진실 공급원으로 정의했습니다.
+               가공된 통계 데이터를 데이터베이스에 저장하지 않고, 원천 세션 데이터를 기반으로 
+               클라이언트에서 집계를 수행해 생산성 지표를 계산하도록 설계했습니다.
+               이 구조는 Dual-write로 인한 데이터 불일치 위험을 제거합니다.`,
 
           en: `To maintain data integrity, the focus_sessions table
-        was defined as the Single Source of Truth (SSOT).
-        Instead of storing derived statistics in the database,
-        productivity metrics are calculated through
-        client-side aggregation based on the raw session data.
-        This design removes the risk of data inconsistencies
-        caused by dual-write updates.`,
+               was defined as the Single Source of Truth (SSOT).
+               Instead of storing derived statistics in the database,
+               productivity metrics are calculated through
+               client-side aggregation based on the raw session data.
+               This design removes the risk of data inconsistencies
+               caused by dual-write updates.`,
 
-          ja: `データ整合性を保つため、
-    focus_sessions テーブルを単一の真実のソース(SSOT)として定義しました。
-    加工された統計データをデータベースに保存せず、
-    セッションの生データを基にクライアント側で集約処理を行い
-    生産性指標を計算する設計としました。
-    この構造により、Dual-writeによるデータ不整合のリスクを排除しています。`,
+          ja: `データ整合性を保つため、focus_sessions テーブルを単一の真実のソースとして定義しました。
+              加工された統計データをデータベースに保存せず、セッションの生データを基にクライアント側で
+              集約処理を行い生産性指標を計算する設計としました。
+              この構造により、Dual-writeによるデータ不整合のリスクを排除しています。`,
         },
       },
       {
@@ -245,8 +233,10 @@ export const PROJECTS_DATA: ProjectsData = {
           Centralized shared mutations in Zustand store actions while isolating UI-only state within components to ensure deterministic rendering.
           Controlled client-side hydration to minimize layout shifts. In local Lighthouse measurements, the application recorded a CLS score of 0.003.`,
           ja: `Page → Hook → Component 構造を基盤に、明示的な状態所有権を定義しました。
-          共有状態の変更はZustandストアアクションに集約し、UI専用状態はコンポーネント内部に隔離することで決定論的なレンダリングを実現しました。
-         また、クライアントサイドのハイドレーションを制御することでレイアウトシフトを最小限に抑え、ローカルのLighthouse測定基準でCLS 0.003を記録しました。`,
+          共有状態の変更はZustandストアアクションに集約し、UI専用状態はコンポーネント内部に
+          隔離することで決定論的なレンダリングを実現しました。
+          また、クライアントサイドのハイドレーションを制御することでレイアウトシフトを最小限に抑え、
+          ローカルのLighthouse測定基準でCLS 0.003を記録しました。`,
         },
       },
       {
@@ -258,12 +248,12 @@ export const PROJECTS_DATA: ProjectsData = {
         description: {
           ko: `React Query를 도입하여 서버 상태와 클라이언트 UI 상태를 엄격히 분리했습니다.
                Supabase(PostgreSQL) 기반의 영속성 계층을 구축하고, 
-               계층적 쿼리 키(Query Keys) 전략을 통해 
-               효율적인 캐시 무효화(Invalidation)와 데이터 동기화를 구현했습니다.`,
+               계층적 쿼리 키 전략을 통해 효율적인 캐시 무효화와 데이터 동기화를 구현했습니다.`,
           en: `Adopted React Query to clearly separate server state from client UI state.
                Implemented a data layer based on Supabase (PostgreSQL) and designed hierarchical Query Keys to support efficient cache invalidation and data synchronization.`,
           ja: `React Queryを導入し、サーバー状態とクライアントUI状態を厳格に分離しました。
-               Supabase(PostgreSQL)ベースの永続化レイヤーを構築し、階層的なクエリキー(Query Keys)戦略を通じて効率的なキャッシュ無効化とデータ同期を実装しました。`,
+               Supabase(PostgreSQL)ベースの永続化レイヤーを構築し、階層的なクエリキー戦略を通じて
+              効率的なキャッシュ無効化とデータ同期を実装しました。`,
         },
       },
     ],

--- a/src/constants/skills.ts
+++ b/src/constants/skills.ts
@@ -10,12 +10,14 @@ export const SKILLS_DATA: SkillCategory[] = [
           {
             ko: 'Hook 기반 아키텍처를 활용한 재사용 가능한 컴포넌트 설계',
             en: 'Designing reusable components using a hook-based architecture',
-            ja: 'Hookベースのアーキテクチャを活用した再利用可能なコンポーネント設計',
+            ja: `Hookベースのアーキテクチャを活用した再利用可能な
+                   コンポーネント設計`,
           },
           {
             ko: '예측 가능한 UI 성능 유지를 위한 렌더링 스코프 최적화',
             en: 'Controlling rendering scope to maintain predictable UI performance',
-            ja: '予測可能なUIパフォーマンス維持のためのレンダリングスコープの最適化',
+            ja: `予測可能なUIパフォーマンス維持のための
+                  レンダリングスコープの最適化`,
           },
           {
             ko: '관심사 분리가 명확한 SPA 애플리케이션 구조 설계',
@@ -33,9 +35,9 @@ export const SKILLS_DATA: SkillCategory[] = [
         name: 'TypeScript',
         details: [
           {
-            ko: '인터페이스 기반의 컴포넌트 간 데이터 규격(Contract) 설계',
+            ko: '인터페이스 기반의 컴포넌트 간 데이터 규격( 설계',
             en: 'Designing interface-driven data contracts between components',
-            ja: 'インターフェース駆動のコンポーネント間データ契約(Contract)設計',
+            ja: 'インターフェース駆動のコンポーネント間データ契約設計',
           },
           {
             ko: '모호한 UI 상태 방지를 위한 명시적 상태 모델링',
@@ -53,19 +55,25 @@ export const SKILLS_DATA: SkillCategory[] = [
         name: 'State Management',
         details: [
           {
-            ko: 'TanStack Query를 활용한 서버 상태 관리 및 도메인 중심의 계층적 쿼리 키 설계',
+            ko: `TanStack Query를 활용한 서버 상태 관리 및 도메인 중심의 
+                계층적 쿼리 키 설계`,
             en: 'Server state management and domain-driven hierarchical query key design using TanStack Query',
-            ja: 'TanStack Queryを活用したサーバー状態管理およびドメイン中心の階層的クエリキー設計',
+            ja: `TanStack Queryを活用したサーバー状態管理および
+                ドメイン中心の階層的クエリキー設計`,
           },
           {
-            ko: 'Zustand 기반 단일 진실 공급원(SSOT) 구축으로 UI 상태의 일관성과 데이터 정합성 확보',
+            ko: `Zustand 기반 단일 진실 공급원(SSOT) 구축으로 
+                UI 상태의 일관성과 데이터 정합성 확보`,
             en: 'Establishing a Single Source of Truth (SSOT) with Zustand to ensure UI state consistency',
-            ja: 'Zustandベースの単一真実のソース(SSOT)構築によるUI状態の一貫性確保',
+            ja: `Zustandベースの単一真実のソース(SSOT)構築による
+                UI状態の一貫性確保`,
           },
           {
-            ko: '서버 상태 집계(Aggregation)와 클라이언트 UI 상태의 역할을 명확히 분리',
+            ko: `서버 상태 집계(Aggregation)와 클라이언트 UI 상태의 역할을 
+                 명확히 분리`,
             en: 'Clear separation between server state aggregation and client UI state',
-            ja: 'サーバー状態の集約(Aggregation)とクライアントUI状態の明確な役割分離',
+            ja: `サーバー状態の集約(Aggregation)とクライアントUI状態の
+                明確な役割分離`,
           },
         ],
       },
@@ -79,19 +87,25 @@ export const SKILLS_DATA: SkillCategory[] = [
         name: 'Workflow & Strategy',
         details: [
           {
-            ko: `Git Flow 기반 브랜칭 전략을 활용한 협업 및 점진적 리팩토링 경험`,
+            ko: `Git Flow 기반 브랜칭 전략을 활용한 협업 및 
+                  점진적 리팩토링 경험`,
             en: 'Experience with Git Flow-based branching strategies and incremental refactoring workflows',
-            ja: 'Git Flowベースのブランチ戦略を活用した協働および段階的リファクタリングの経験',
+            ja: `Git Flowベースのブランチ戦略を活用した協働および
+                段階的リファクタリングの経験`,
           },
           {
-            ko: 'AI 도구를 활용한 디버깅 가속화 및 코드 리뷰 보조 워크플로우 활용 경험',
+            ko: `AI 도구를 활용한 디버깅 가속화 및 코드 리뷰 보조 워크플로우 
+                활용 경험`,
             en: 'Experience using AI tools to accelerate debugging and assist code review workflows',
-            ja: 'AIツールを活用したデバッグ加速およびコードレビュー補助ワークフローの経験',
+            ja: `AIツールを活用したデバッグ加速およびコードレビュー補助
+                ワークフローの経験`,
           },
           {
-            ko: '기술적 의사결정 과정 기록 및 정기적인 리팩토링을 통한 기술 부채 관리',
+            ko: `기술적 의사결정 과정 기록 및 정기적인 리팩토링을 통한 
+                기술 부채 관리`,
             en: 'Managing technical debt through documented technical decisions and periodic refactoring',
-            ja: '技術的意思決定の記録および定期的リファクタリングによる技術的負債の管理',
+            ja: `技術的意思決定の記録および定期的リファクタリングによる
+                  技術的負債の管理`,
           },
         ],
       },


### PR DESCRIPTION
## 📌 Description

Refine the portfolio's content and presentation around the home hero, project overview, and skills sections.  
This PR also updates the project architecture visuals and fixes the architecture diagram image path so it resolves correctly in production.

Fix: #27 
---

## 🛠️ Key Changes

* **Refine portfolio copy across sections**: Polished wording and translations in `Home`, `Experience`, `Projects`, and `Skills` content to improve clarity and consistency across Korean, English, and Japanese.
* **Improve project architecture narrative**: Updated project architecture descriptions to better explain data flow, state ownership, and aggregation strategy with more consistent line breaks.
* **Fix architecture diagram path**: Changed the architecture diagram import to use the public `/images/...` path so the image renders correctly in the built app.
* **Enhance hero section layout**: Adjusted the tech icon grid (responsive column count and card sizing) to improve visual balance across breakpoints.
* **Polish project hero text layout**: Tuned spacing and typography in the project hero introduction/overview block for better readability.
* **Improve skills list readability**: Allowed multiline skill details via `whitespace-pre-line` so long descriptions wrap more naturally.

---

## 🧠 Design Notes

* **Content tone & alignment**: Focused on a consistent narrative around data integrity, clear state ownership, and predictable data flow, ensuring that all three languages communicate the same technical story.
* **Readability & line breaking**: Carefully adjusted line breaks (especially in Korean and Japanese) to avoid awkward mid-phrase wraps, prioritizing scannability in card-based layouts.
* **Visual hierarchy in hero & project sections**: Small spacing and typography tweaks are intended to create a clearer hierarchy between titles, introductions, and detailed descriptions without introducing new visual components.
* **Asset path robustness**: Moving the architecture diagram to use a public path avoids bundler-specific assumptions and ensures the image is reliably served in production environments.

---

## 📸 ScreenShots

`before`
<img width="1026" height="521" alt="before" src="https://github.com/user-attachments/assets/2cb758b3-975c-404b-bb7a-a9ea91a90d38" />

`after`
<img width="1023" height="530" alt="after" src="https://github.com/user-attachments/assets/3a676f3f-2be4-42c2-8ddb-7d1b9eb806e7" />

---

## ✅ Checklist

* [x] All text changes reviewed for consistency across `ko/en/ja`.
* [x] Build passes locally without TypeScript or bundling errors.
* [x] Architecture diagram renders correctly on the project page.
* [x] Layout checked on at least two breakpoints (e.g. mobile and desktop).
