### PR TITLE
feat/mobile-language-switcher-placement

### DIFF
--- a/src/components/header/NavbarMenu.tsx
+++ b/src/components/header/NavbarMenu.tsx
@@ -66,48 +66,55 @@ export default function NavbarMenu() {
             </span>
           </a>
 
-          <div className='hidden items-center gap-8 md:flex'>
-            <ul className='flex items-center gap-1'>
-              {navItems.map((item) => (
-                <li key={item.href}>
-                  <a
-                    href={item.href}
-                    className={cn(
-                      'relative rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                      activeSection === item.href.slice(1)
-                        ? 'text-cyan-400 border border-cyan-500/30  shadow-lg shadow-cyan-500/20'
-                        : 'text-muted-foreground hover:text-cyan-400',
-                    )}
-                  >
-                    {activeSection === item.href.slice(1) && (
-                      <motion.span
-                        layoutId='activeNav'
-                        className='absolute inset-0 rounded-md bg-[#ffffff08]'
-                        transition={{
-                          type: 'spring',
-                          bounce: 0.2,
-                          duration: 0.6,
-                        }}
-                      />
-                    )}
-                    <span className='relative z-10'>{item.label}</span>
-                  </a>
-                </li>
-              ))}
-            </ul>
+          <div className='flex items-center gap-3'>
+            <div className='hidden items-center gap-8 md:flex'>
+              <ul className='flex items-center gap-1'>
+                {navItems.map((item) => (
+                  <li key={item.href}>
+                    <a
+                      href={item.href}
+                      className={cn(
+                        'relative rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                        activeSection === item.href.slice(1)
+                          ? 'text-cyan-400 border border-cyan-500/30  shadow-lg shadow-cyan-500/20'
+                          : 'text-muted-foreground hover:text-cyan-400',
+                      )}
+                    >
+                      {activeSection === item.href.slice(1) && (
+                        <motion.span
+                          layoutId='activeNav'
+                          className='absolute inset-0 rounded-md bg-[#ffffff08]'
+                          transition={{
+                            type: 'spring',
+                            bounce: 0.2,
+                            duration: 0.6,
+                          }}
+                        />
+                      )}
+                      <span className='relative z-10'>{item.label}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
 
-            <LanguageSwitcher current={language} onChange={setLanguage} />
+              <LanguageSwitcher current={language} onChange={setLanguage} />
+            </div>
+
+            <div className='md:hidden flex items-center gap-2'>
+              <LanguageSwitcher current={language} onChange={setLanguage} />
+              <Button
+                variant='ghost'
+                size='icon'
+                onClick={() => setIsOpen(!isOpen)}
+                aria-label='Open menu'
+              >
+                {isOpen ? <X /> : <Menu />}
+              </Button>
+            </div>
           </div>
-          <Button
-            className='md:hidden'
-            variant='ghost'
-            onClick={() => setIsOpen(!isOpen)}
-          >
-            {isOpen ? <X /> : <Menu />}
-          </Button>
         </div>
 
-        <div className='md:hidden'>
+        <div>
           <MobileMenu
             isOpen={isOpen}
             navItems={navItems}


### PR DESCRIPTION
## 📌 Description

Improves mobile navigation usability by keeping the language switcher visible when the navbar collapses into a hamburger menu.
On small screens, the language switcher is now displayed next to the hamburger icon instead of being hidden.

Fixes: #31 

---

## 🛠️ Key Changes

* **Mobile navbar action group**: Added a mobile-only right-side group that renders the language switcher beside the hamburger menu.
* **Desktop behavior preserved**: Kept the existing desktop layout where nav links and language switcher remain visible in the main navbar row.
* **Hamburger button consistency**: Set the mobile menu button to icon size for consistent visual alignment with the language switcher.

---

## 🧠 Design Notes

* **Visibility-first on mobile**: Language switching is treated as a primary action, not hidden behind menu expansion.
* **Responsive separation**: Desktop and mobile controls are explicitly split with breakpoint-based rendering for predictable behavior.
* **Minimal scope**: This PR intentionally excludes navbar-hero spacing adjustments and focuses only on language switcher placement.

---

## 📸 ScreenShots

`before`
<img width="514" height="73" alt="2" src="https://github.com/user-attachments/assets/72eeb7b6-a5a3-45b5-b8c7-f3440471b5e5" />

`after`
<img width="490" height="61" alt="1" src="https://github.com/user-attachments/assets/34f996d4-ab78-4bfa-8a39-3030cf770233" />

---

## ✅ Checklist

* [x] Language switcher remains visible on mobile when navbar is collapsed.
* [x] Language switcher appears adjacent to the hamburger icon on small screens.
* [x] Desktop navbar layout remains unchanged.

