### PR TITLE
docs: fix Live Demo links in multilingual READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,7 +10,7 @@
 
 ## 🔗 Live Demo
 
-[👉 ポートフォリオサイトを見る](choinaa-portfolio.vercel.app)
+[👉 ポートフォリオサイトを見る](https://choinaa-portfolio.vercel.app/)
 
 ## 🌟 主な特徴 (Key Highlights)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -10,7 +10,7 @@
 
 ## 🔗 Live Demo
 
-[👉 포트폴리오 웹사이트 방문하기](choinaa-portfolio.vercel.app)
+[👉 포트폴리오 웹사이트 방문하기](https://choinaa-portfolio.vercel.app/)
 
 ## 🌟 주요 특징
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## 🔗 Live Demo
 
-[👉 Visit My Portfolio Website](choinaa-portfolio.vercel.app)
+[👉 Visit My Portfolio Website](https://choinaa-portfolio.vercel.app/)
 
 ## 🌟 Key Highlights
 


### PR DESCRIPTION
## 📌 Description

The Live Demo links in README.md, README.ko.md, and README.ja.md were missing the https:// scheme, so they did not behave as proper external URLs in Markdown renderers. 
This PR updates all three files to use the full portfolio URL with HTTPS and a trailing slash for consistent, clickable demo links.

---

## 🛠️ Key Changes

* **README (EN/KO/JA)**: Replace relative-style demo URL with https://choinaa-portfolio.vercel.app/ in the Live Demo section.

---

## 🧠 Design Notes

* **No app/runtime impact**: Documentation-only change; no code or dependency updates.
* **Consistency**:  Same URL shape across English, Korean, and Japanese READMEs so translators and readers see one canonical demo link.

---

## ✅ Checklist

* [x] Live Demo links use a full HTTPS URL in all three README variants
* [x] Wording and structure of README sections unchanged aside from the link fix


