### PR TITLE
feat/content-layered-updates

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -19,7 +19,7 @@ export function ContactSection() {
         <SectionHeader eyebrow='Contact' title='Get In Touch' />
 
         <motion.div {...fadeInUp} className='mb-8'>
-          <div className='leading-relaxed text-muted-foreground select-none'>
+          <div className='leading-relaxed text-muted-foreground select-none whitespace-pre-line'>
             {content.description.map((line, idx) => (
               <p key={idx}>{line[language]}</p>
             ))}
@@ -29,7 +29,7 @@ export function ContactSection() {
         <motion.div
           {...fadeInUp}
           transition={{ duration: 0.5, delay: 0.1 }}
-          className='flex flex-col items-center text-center'
+          className='flex flex-col items-stretch text-center'
         >
           <div className='grid gap-8 md:grid-cols-2'>
             <div className='flex flex-col gap-4'>
@@ -87,15 +87,15 @@ export function ContactSection() {
                 {content.openToWork.badge[language]}
               </h3>
 
-              <p className='mt-3 text-lg font-semibold text-foreground'>
+              <p className='mt-1 text-lg font-semibold text-foreground'>
                 {content.openToWork.headline[language]}
               </p>
 
-              <p className='mt-3 leading-relaxed text-left text-muted-foreground'>
+              <p className='mt-2 leading-relaxed text-left text-muted-foreground whitespace-pre-line'>
                 {content.openToWork.description.map((item) => item[language])}
               </p>
 
-              <div className='mt-6 flex items-center gap-2'>
+              <div className='mt-3 flex items-center gap-2'>
                 <span className='relative flex h-2.5 w-2.5'>
                   <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-cyan-500 opacity-75' />
                   <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-cyan-500' />

--- a/src/components/experience/FullExperienceCard.tsx
+++ b/src/components/experience/FullExperienceCard.tsx
@@ -31,7 +31,7 @@ export default function FullExperienceCard({
           </span>
         </div>
 
-        <p className='text-sm text-zinc-400 leading-relaxed mb-8 max-w-3xl'>
+        <p className='text-sm text-zinc-400 leading-relaxed mb-8 max-w-3xl whitespace-pre-line '>
           {exp.description[language]}
         </p>
 

--- a/src/components/project/Challenges.tsx
+++ b/src/components/project/Challenges.tsx
@@ -13,6 +13,7 @@ export function Challenges({ challenges, language }: ChallengesProps) {
       {challenges.map((c, i) => (
         <Card key={i}>
           <CardContent className='p-6 space-y-4'>
+            <h3 className='text-center'>{c.layer[language]}</h3>
             <div>
               <span className='text-xs uppercase text-red-400'>Problem</span>
               <p className='text-sm pt-1 text-muted-foreground/80'>

--- a/src/constants/contactContent.ts
+++ b/src/constants/contactContent.ts
@@ -3,24 +3,21 @@ import type { ContactContent } from '@/types/portfolio';
 export const CONTACT_CONTENT: ContactContent = {
   description: [
     {
-      en: 'Frontend Engineer dedicated to designing reliable systems based on data integrity and building high-performance, user-centric interfaces.',
-      ko: '데이터 무결성을 기반으로 신뢰할 수 있는 시스템을 설계하고, 사용자 중심의 고성능 인터페이스를 구현하는 프론트엔드 엔지니어입니다.',
-      ja: 'データの完全性を基盤に信頼性の高いシステムを設計し、ユーザー中心の高性能インターフェースを実装するフロントエンドエンジニアです。',
-    },
-    {
-      en: 'Integrating my professional background in precise game localization into software design, I contribute to team productivity through logical communication.',
-      ko: '게임 로컬라이징 실무에서 다룬 정밀한 텍스트/상호작용 경험을 소프트웨어 설계에 녹여내며, 논리적인 커뮤니케이션으로 팀의 생산성에 기여합니다.',
-      ja: 'ゲームローカライズ実務で培った精密なテキスト・相互作用の経験をソフトウェア設計に活かし、論理的なコミュニケーションでチームの生産性に貢献します。',
-    },
-    {
-      en: 'I am currently seeking new frontend opportunities and am ready to contribute to both technical challenges and business growth.',
-      ko: '현재 새로운 프론트엔드 기회를 찾고 있으며, 기술적 도전과 비즈니스 성장을 함께 고민할 준비가 되어 있습니다.',
-      ja: '現在、フロントエンドエンジニアとしての新たな機会を探しており、技術的挑戦とビジネスの成長を共に追求する準備ができています。',
-    },
-    {
-      en: 'I typically respond within 24 hours.',
-      ko: '24시간 이내에 답변드리겠습니다.',
-      ja: '通常24時間以内に返信いたします。',
+      ko: `텍스트를 검수하다 화면을 만들게 된 프론트엔드 개발자입니다. 
+          로컬라이징에서 쌓은 꼼꼼함과 일관성에 대한 감각을 개발에 녹이고 있습니다.
+          현재 프론트엔드 포지션을 찾고 있습니다. 
+          24시간 이내에 답변드리겠습니다.`,
+
+      en: ` A frontend developer who went from checking text to building screens.
+      I bring the precision and consistency I developed in game localization
+      into how I write and structure frontend code.
+      Currently looking for frontend opportunities.
+      I typically respond within 24 hours.`,
+
+      ja: `テキストの検収から画面制作へ転向したフロントエンドエンジニアです。
+      ゲームローカライズで培った正確さと一貫性へのこだわりを、フロントエンド開発に活かしています。
+      現在、フロントエンドエンジニアとしての機会を探しています。
+      通常24時間以内に返信いたします。`,
     },
   ],
   openToWork: {
@@ -36,9 +33,15 @@ export const CONTACT_CONTENT: ContactContent = {
     },
     description: [
       {
-        en: 'I am looking for roles where I can leverage my expertise in state management and performance optimization to build high-impact products.',
-        ko: '상태 관리와 성능 최적화 역량을 발휘하여 임팩트 있는 제품 개발에 기여하고, 함께 성장할 수 있는 포지션을 희망합니다.',
-        ja: '状態管理とパフォーマンス最適化のスキルを活かし、価値あるプロダクト開発に貢献しながら共に成長できるポジションを希望しています。',
+        en: `Looking for a frontend role where React and TypeScript are part of the stack.
+             I care about how data flows through an application,
+             and I work best in teams where attention to detail matters.`,
+        ko: `React · TypeScript 기반 프론트엔드 포지션을 찾고 있습니다.
+             데이터 흐름을 명확하게 설계하는 것을 중요하게 생각하며, 
+             꼼꼼하게 일하는 팀에서 함께하고 싶습니다.`,
+        ja: `React・TypeScriptを使用するフロントエンドのポジションを探しています。
+              データがアプリケーション内をどう流れるかを大切にしており、
+              細部へのこだわりを持つチームで働きたいと考えています。`,
       },
     ],
     availability: 'Available for hire',

--- a/src/constants/experience.ts
+++ b/src/constants/experience.ts
@@ -16,7 +16,8 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     },
     isPrimary: true,
     description: {
-      ko: '로컬라이징에서 코드로 반복 작업을 해결한 경험을 계기로, 정적인 텍스트가 아닌 동적인 화면을 직접 설계하고 구현하는 프론트엔드 엔지니어로 전향했습니다.',
+      ko: `로컬라이징에서 코드로 반복 작업을 해결한 경험을 계기로, 정적인 텍스트가 아닌 동적인 화면을 직접 설계하고 구현하는 
+            프론트엔드 엔지니어로 전향했습니다.`,
       en: 'Transitioned to frontend engineering after realizing through localization work that I wanted to build the dynamic interfaces users interact with—not just validate the text within them.',
       ja: 'ローカライズ業務でコードを使って反復作業を解決した経験をきっかけに、静的なテキストではなく動的な画面を自ら設計・実装するフロントエンドエンジニアへ転向しました。',
     },
@@ -37,13 +38,13 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
       },
       {
         ko: '자료구조, 알고리즘, 정보통신망 등 컴퓨터 과학 전공 과목 이수를 통해 프론트엔드 개발의 기술적 기초를 다졌습니다.',
-        en: 'Strengthened technical foundations through computer science coursework, including Data Structures, Algorithms, and Information and Communications Networks..',
+        en: 'Strengthened technical foundations through computer science coursework, including Data Structures, Algorithms, and Information and Communications Networks.',
         ja: 'データ構造、アルゴリズム、情報通信ネットワークなどの専攻科目を通じて、フロントエンド開発の技術的な基礎を固めました。',
       },
       {
-        ko: '캐싱 전략과 효율적인 데이터 페칭 패턴을 적용하여 애플리케이션의 성능과 사용자 경험을 개선했습니다.',
-        en: 'Implemented optimized data fetching and caching strategies to improve user experience and application performance.',
-        ja: 'キャッシュ戦略と効率的なデータフェッチパターンを適用し、アプリケーションのパフォーマンスとUXを向上させました。',
+        ko: 'TanStack Query의 캐싱 전략을 활용해 불필요한 서버 요청을 줄이고 데이터 동기화 흐름을 개선했습니다.',
+        en: 'Reduced unnecessary server requests and improved data synchronization flow using TanStack Query caching strategies.',
+        ja: 'TanStack Queryのキャッシュ戦略を活用し、不要なサーバーリクエストを削減してデータ同期の流れを改善しました。',
       },
     ],
   },
@@ -135,9 +136,9 @@ export const EXPERIENCE_DATA: ExperienceItem[] = [
     },
     isCondensed: true,
     description: {
-      ko: '이러닝 서비스 어카운트 관리 및 시스템 운영 보조 업무를 수행했습니다.',
-      en: 'Supported e-learning platform operations by managing user accounts and performing routine system checks.',
-      ja: 'e-ラーニングサービスのアカウント管理およびシステム運営補助業務を担当しました。',
+      ko: 'HTML 동작확인 페이지를 직접 관리하며 코드와 처음 접점을 가졌습니다. 계정 관리 및 시스템 운영 보조 업무를 담당했습니다.',
+      en: 'Managed HTML-based system check pages directly—my first hands-on experience with code.Also handled account management and platform operations support.',
+      ja: 'HTMLで作成された動作確認ページを直接管理し、コードとの最初の接点となりました。アカウント管理およびシステム運営補助業務も担当しました。',
     },
     achievements: [
       {

--- a/src/constants/home.ts
+++ b/src/constants/home.ts
@@ -5,11 +5,11 @@ export const HOME_DATA: HomeData = {
   subtitle: {
     en: `Building consistent, predictable UI by defining clear data flows and state ownership.`,
     ko: `데이터 흐름과 상태를 명확하게 
-         정의하여, 일관성 있고 예측 가능한 
-         UI를 만드는 것을 목표로 합니다.`,
+         정의하여, 일관성 있고 
+         예측 가능한 UI를 만듭니다.`,
     ja: `データの流れと状態を明確に
-        定義し、一貫性があり予測可能な
-        UI構築を目指しています。`,
+        定義し、一貫性があり
+        予測可能なUIを構築します。`,
   },
   description: {
     en: `In game localization, I learned that when consistency breaks—

--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -90,25 +90,39 @@ export const PROJECTS_DATA: ProjectsData = {
 
   challenges: [
     {
+      layer: {
+        ko: '클라이언트 상태',
+        en: 'Client State',
+        ja: 'クライアント状態',
+      },
       problem: {
-        ko: `기능 확장 및 외부 DB 연동 과정에서 전역 상태로 관리하던 날짜 데이터가 페이지 간에 간섭을 일으키는 구조적 결함을 발견했습니다.`,
+        ko: `기능 확장 및 외부 DB 연동 과정에서 전역 상태로 관리하던 날짜 데이터가 
+              페이지 간에 간섭을 일으키는 구조적 결함을 발견했습니다.`,
         en: `Identified structural flaws where date data managed in global state caused cross-page interference during feature expansion and DB integration.`,
         ja: `機能拡張の過程で、グローバル状態で管理していた日付データがページ間で干渉を引き起こす構造的な欠陥を発見しました。`,
       },
       solution: {
-        ko: `공통 데이터의 무분별한 전역화를 지양하고, 페이지별 목적에 맞게 지역 상태(useState)로 격리하여 상태 간섭을 원천 차단했습니다.`,
+        ko: `공통 데이터의 무분별한 전역화를 지양하고, 페이지별 목적에 맞게 
+              지역 상태로 격리하여 상태 간섭을 원천 차단했습니다.`,
         en: `Avoided indiscriminate globalization of shared data and isolated it into page-specific local states to eliminate state interference.`,
-        ja: `共通データの無分別なグローバル化を避け、ページごとの目的に合わせてローカル状態(useState)に分離することで干渉を遮断しました。`,
+        ja: `共通データの無分別なグローバル化を避け、ページごとの目的に合わせて
+              ローカル状態に分離することで干渉を遮断しました。`,
       },
       result: {
-        ko: `상태 오염 문제를 근본적으로 해결했으며, 아키텍처의 질은 데이터의 성격과 소유권이 결정한다는 
-              설계 원칙을 확립했습니다.`,
-        en: `Fundamentally resolved state contamination issues and established a design principle that architecture quality is determined by data nature and ownership.`,
-        ja: `状態汚染問題を根本的に解決し、アーキテクチャの質はデータの性質と所有権が決定するという
-              設計原則を確立しました。`,
+        ko: `상태 오염 문제를 근본적으로 해결했습니다. 이후 데이터를 전역으로 올리기 전에
+            "이 데이터가 정말 여러 페이지에 필요한가"를 먼저 따지는 습관이 생겼습니다.`,
+        en: `Fundamentally resolved state contamination issues.
+             Now I ask "does this data actually need to be global?" before lifting state.`,
+        ja: `状態汚染問題を根本的に解決しました。以降、状態をグローバルに引き上げる前に
+             「このデータは本当に複数ページで必要か」を先に考えるようになりました。`,
       },
     },
     {
+      layer: {
+        ko: '데이터 모델링',
+        en: 'Data Modeling',
+        ja: 'データモデリング',
+      },
       problem: {
         ko: `집중 세션 저장과 통계 업데이트를 동시에 처리하는
              Dual-write 구조에서 데이터 정합성 문제가 발생할 가능성을 확인했습니다.`,
@@ -119,17 +133,74 @@ export const PROJECTS_DATA: ProjectsData = {
       },
       solution: {
         ko: `가공된 통계 컬럼을 제거하고 원천 데이터인 focus_sessions를 기반으로 
-        실시간 집계(Aggregation) 쿼리 방식으로 아키텍처를 개편했습니다.`,
+              실시간 집계 쿼리 방식으로 아키텍처를 개편했습니다.`,
         en: `Eliminated derived stat columns and refactored the architecture to use real-time aggregation queries based on the source data, focus_sessions.`,
         ja: `加工された統計カラムを削除し、ソースデータであるfocus_sessionsに基づいた
-            リアルタイム集約(Aggregation)クエリ方式にアーキテクチャを刷新しました。`,
+            リアルタイム集約クエリ方式にアーキテクチャを刷新しました。`,
       },
       result: {
-        ko: `데이터 결함 가능성을 원천 차단하여 시스템 신뢰성을 확보했으며, 
-        데이터 무결성을 보장하는 견고한 데이터 모델링을 완성했습니다.`,
-        en: `Ensured system reliability by eliminating potential data flaws and completed a robust data modeling that guarantees integrity.`,
-        ja: `データ欠損の可能性を根本的に遮断してシステムの信頼性を確保し、
-            データの完全性を保証する堅牢なデータモデリングを完成させました。`,
+        ko: `Dual-write 구조를 제거하고 원천 데이터 기반 집계 방식으로 전환했습니다.
+            기존에는 focus_sessions 저장 후 통계 업데이트가 실패하면 UI에 집중 시간이 표시되지 않거나, 
+            모달에서 2배로 표기되는 문제가 있었는데 구조 자체를 바꾸면서 이런 정합성 오류가 발생할 
+            여지를 없앴습니다. 예상보다 리팩토링 범위가 컸지만, 오히려 전체 데이터 흐름이 단순해졌습니다.`,
+        en: `Eliminated the dual-write structure and switched to real-time aggregation 
+              from focus_sessions as the single source of truth.
+              Previously, a failed stats update after session insert caused issues such as 
+              focus time not appearing in the UI or being displayed as double in the modal.
+              Restructuring at the architecture level removed the root cause entirely.
+              The refactoring scope was larger than expected, but the overall data flow 
+              became significantly simpler as a result.`,
+        ja: `Dual-write構造を削除し、focus_sessionsを唯一のソースとした
+              リアルタイム集約方式に切り替えました。以前は、セッション保存後の統計更新が失敗すると、
+              UIに集中時間が表示されなかったり、モーダルで2倍に表示されるなどの
+              不整合が発生していました。
+              アーキテクチャレベルで構造を変えることで、こうした問題の発生余地をなくしました。
+              リファクタリングは想定より複雑でしたが、全体のデータフローはむしろシンプルになりました。`,
+      },
+    },
+    {
+      layer: {
+        ko: '서버 상태',
+        en: 'Server State',
+        ja: 'サーバー状態',
+      },
+      problem: {
+        ko: `React Query에서 서로 다른 query key를 사용하는 구조로 인해,
+             동일한 Todo 데이터가 페이지 간에 일관되지 않게 표시되는 문제를 발견했습니다.`,
+        en: `Identified a data inconsistency issue where the same Todo data was displayed differently across pages due to separate React Query keys.`,
+        ja: `React Queryで異なるクエリキーを使用していたことで、
+             同一のTodoデータがページ間で一貫して表示されない問題を発見しました。`,
+      },
+      solution: {
+        ko: `Todo 생성 시 특정 날짜 쿼리만 invalidate하던 구조를 개선하여,
+             전체 리스트와 날짜별 쿼리를 함께 갱신하도록 수정했습니다.
+             이를 통해 분리된 캐시 간의 동기화를 보장했습니다.`,
+        en: `Improved the mutation logic to invalidate both date-specific and global todo queries,
+             ensuring synchronization across separate caches.`,
+        ja: `Todo作成時に日付別クエリのみを無効化していた構造を改善し、
+             全体リストと日付別クエリの両方を更新することでキャッシュ間の同期を確保しました。`,
+      },
+      result: {
+        ko: `초기에는 낙관적 업데이트 문제로 판단했지만, 디버깅 과정에서 query key 분리 구조로 인해
+             invalidation 범위가 일부(byDate)에만 적용되고 
+             allTodos 캐시가 갱신되지 않는 문제가 원인임을 확인했습니다.
+
+             이를 해결하기 위해 query key 구조를 재정의하고, onSuccess 중심 구조를 
+             onMutate/onSettled로 재설계해 캐시 간 일관성을 확보했습니다.`,
+        en: `Initially identified the issue as an optimistic update bug,
+             but debugging revealed the root cause:
+             the query key separation meant invalidation was only applied to byDate,
+             leaving the allTodos cache stale.
+             To resolve this, the query key structure was redefined
+             and the logic was redesigned from onSuccess-based post-processing
+             to an onMutate/onSettled-based optimistic update flow,
+             ensuring consistency across caches.`,
+        ja: `当初は楽観的更新のバグと判断しましたが、デバッグの過程でquery keyの分離構造により
+             invalidationの範囲がbyDateのみに適用され、
+             allTodosキャッシュが更新されないことが原因だと確認しました。
+             解決のためにquery key構造を再定義し、onSuccess基盤の後処理方式から
+             onMutate/onSettled基盤の楽観的更新フローに再設計することで
+             キャッシュ間の一貫性を確保しました。`,
       },
     },
   ],

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -60,6 +60,7 @@ export interface ArchitectureData {
 }
 
 export interface ProjectChallenge {
+  layer: LocalizedText;
   problem: LocalizedText;
   solution: LocalizedText;
   result: LocalizedText;


### PR DESCRIPTION
## 📌 Description

This PR reorganizes and refines portfolio content updates into clear architectural storytelling and improves how multiline localized copy is rendered across key sections.

---

## 🛠️ Key Changes

* **Project challenge model**: Added `layer` metadata to each challenge and expanded challenge narratives (client state, data modeling, server state) in `projects` content.
* **Multilingual copy refresh**: Rewrote parts of home/contact/experience copy for clearer tone and consistency in Korean, English, and Japanese.
* **UI text rendering polish**: Applied whitespace-preserving styles and spacing tweaks so multiline content displays as intended in contact and experience sections.

---

## 🧠 Design Notes

* **Content structure**: Challenge entries now communicate not only problem/solution/result, but also the architectural layer for better scanning and storytelling.
* **Data contract update**: `ProjectChallenge` type now explicitly includes `layer`, aligning rendering logic and content schema.
* **Presentation consistency**: `whitespace-pre-line` and spacing adjustments prevent multiline localization text from collapsing in the UI.

---

## ✅ Checklist

* [x] Content changes were reviewed in all supported languages (KO/EN/JA)
* [x] Updated challenge data matches the `ProjectChallenge` type contract
* [x] Multiline text rendering was verified in Contact and Experience sections
* [x] No lint errors in modified files
* [x] No breaking changes introduced